### PR TITLE
bibliography: pass style from main tex file

### DIFF
--- a/misc/iitthesis.cls
+++ b/misc/iitthesis.cls
@@ -376,7 +376,6 @@
   url=true,
   maxbibnames=99, % Effectively ensure all authors are listed
   language=american, % ... English
-  style=trad-alpha,
   maxalphanames=4 % Only use first 4 names for an initials key
   ]{biblatex}
 \setcounter{biburllcpenalty}{7000}

--- a/thesis.tex
+++ b/thesis.tex
@@ -1,3 +1,6 @@
+% Change the style to trad-plain or another biblatex style as needed.
+\PassOptionsToPackage{style=trad-alpha}{biblatex}
+
 %
 % You may wish to use some of the following options of the iitthesis
 % package:


### PR DESCRIPTION
Allow users to change the style to a numeric style or other styles as needed.

I don't like the place where the command is, but I'm not sure how to put it in the thesis-fields.tex file.