### PR TITLE
Compatibility with XeLaTeX 2023 on Overleaf

### DIFF
--- a/misc/iitthesis-extra.sty
+++ b/misc/iitthesis-extra.sty
@@ -42,10 +42,10 @@
 %%
 
 \def\filename{iitthesis-extra}
-\def\fileversion{v0.3}
-\def\filedate{2012/03/24}
+\def\fileversion{v0.4}
+\def\filedate{2023/10/18}
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{\filename}[\filedate\space\fileversion\space - Technion IIT Thesis extra machinery]
+\ProvidesPackage{misc/\filename}[\filedate\space\fileversion\space - Technion IIT Thesis extra machinery]
 
 
 % for generating dummy text, for those chapters/sections

--- a/misc/iitthesis.cls
+++ b/misc/iitthesis.cls
@@ -22,12 +22,12 @@
 %%
 
 \def\filename{iitthesis}
-\def\fileversion{v0.10}
-\def\filedate{2022/01/14}
+\def\fileversion{v0.11}
+\def\filedate{2023/10/18}
 \NeedsTeXFormat{LaTeX2e}
 \edef\iitthesis@TechnionIITThesis{%
 \filedate\space\fileversion\space - Technion IIT Thesis}
-\ProvidesClass{\filename}[\iitthesis@TechnionIITThesis]
+\ProvidesClass{misc/\filename}[\iitthesis@TechnionIITThesis]
 
 %--------------------------------
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -21,20 +21,20 @@
 % faculty, acknowledgements, etc. etc. The thesis-fields file 
 % contains Hebrew text, and should use the UTF-8 character set
 % encoding (not iso-8859-8-i or windows codepage 1255).
-\include{misc/thesis-fields}
+\input{misc/thesis-fields}
 
 % Personal acknowledgements (are only used for the post-exam
 % version)
-\include{front/personal-acks}
+\input{front/personal-acks}
 
 % A separate file for the abstract - in English and in Hebrew, so
 % you must make sure it's also in the UTF-8 character set encoding.
 %
-\include{front/abstract}
+\input{front/abstract}
 
 % Comment this if you do not want a list of abbreviations and acronyms
 % (if you have used the noabbrevs option).
-\include{front/abbrevs}
+\input{front/abbrevs}
 
 % Additional machinery relevant to any thesis
 % (it's not part of the document class because it's not absolutely
@@ -48,10 +48,10 @@
 % documents. May contains macros for notation algebra, logic,
 % calculus and other fields, as well as general shorthands and
 % LaTeX tricks, and package use commands
-\include{misc/my-general}
+\input{misc/my-general}
 
 % Definitions, settings and tweaks for this thesis specifically
-\include{misc/my-thesis-specific}
+\input{misc/my-thesis-specific}
 
 \begin{document}
 


### PR DESCRIPTION
First commit is to eliminate the path warning (I believe it is better to have no warnings at the template level).
The second fixes the include commands in the preamble.