### PR TITLE
Add ethical statement

### DIFF
--- a/misc/thesis-fields.tex
+++ b/misc/thesis-fields.tex
@@ -30,6 +30,9 @@
 Some results in this thesis have been published as articles by the author and research collaborators in conferences and journals during the course of the author's doctoral research period, the most up-to-date versions of which being:
 
 \butcheredbibliography{front/pubinfo.bib}
+
+The author of this thesis states that the research, including the collection, processing and presentation of data, addressing and comparing to previous research, etc., was done entirely in an honest way, as expected from scientific research that is conducted according to the ethical standards of the academic world. Also, reporting the research and its results in this thesis was done in an honest and complete manner, according to the same standards.
+
 }
 
 \publicationInfoHebrew{%
@@ -40,6 +43,9 @@ Some results in this thesis have been published as articles by the author and re
 \begin{otherlanguage}{english}%
 \butcheredbibliography{front/pubinfo.bib}
 \end{otherlanguage}%
+
+מחבר תזה זו מצהיר כי המחקר כלל איסוף נתונים, עיבודם והצגתם, התייחסות והשוואה למחקרים קודמים וכו', נעשה כולו בצורה ישרה, כמצופה ממחקר מדעי המבוצע לפי אמות המידה האתיות של העולם האקדמי. כמו כן, הדיווח על המחקר ותוצאותיו בחיבור זה נעשה בצורה ישרה ומלאה, לפי אותן אמות מידה.
+
 }
 
 \addbibresource{back/general.bib}


### PR DESCRIPTION
Solve #51. An important motivation worth noting to include this change is the following: It wasn't trivial to copy paste that text from the PDF linked in @samer152's [comment](https://github.com/eyalroz/technion-iit-thesis/issues/51#issuecomment-1344193961) (at least for me, here on GNU/Linux, with [evince](https://gitlab.gnome.org/GNOME/evince)) - it was scrambled with all kind of invisible unicode characters that were copied to my `$EDITOR`, to the point I realized it'd be easier to use OCR (I asked ChatGPT though)!

Perhaps, since this is an ethical statement, it should be commented, and the author will have to uncomment it for the sake of "approving the statement"?
