### PR TITLE
2 Makefile & latexmk improvements

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -6,6 +6,11 @@ push @generated_exts, 'glo', 'gls', 'glg';
 push @generated_exts, 'acn', 'acr', 'alg';
 push @generated_exts, 'ntn', 'not', 'nlg';
 
+$aux_dir = 'aux';
+$out_dir = 'aux';
+$pdflatex = 'xelatex --shell-escape --interaction=nonstopmode %O %S';
+$pdf_mode = 1;
+
 $clean_ext .= " acr acn alg glo gls glg ist not ntn";
 
 sub run_makeglossaries {

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ FIGURES := $(shell find graphics/* -type f)
 all: symlink once
 
 once: symlink
-	$(LATEXMK) $(LATEXMKOPT) -pdflatex="$(LATEX) $(LATEXOPT) %O %S" $(MAIN)
+	$(LATEXMK) $(LATEXMKOPT) -pdflatex="$(LATEX) $(LATEXOPT) $(NONSTOP) %O %S" $(MAIN)
 
 .refresh:
 	touch .refresh

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,10 @@
 # http://tex.stackexchange.com/questions/40738/how-to-properly-make-a-latex-project
 #
 
-LATEX=xelatex
-LATEXOPT=--shell-escape
-NONSTOP=--interaction=nonstopmode
+# Also set in .latexmkrc
 AUXDIR=aux
 
 LATEXMK=latexmk
-LATEXMKOPT=-pdf -outdir=$(AUXDIR) -auxdir=$(AUXDIR)
 CONTINUOUS=-pvc
 
 MAIN=thesis
@@ -29,13 +26,13 @@ FIGURES := $(shell find graphics/* -type f)
 all: symlink once
 
 once: symlink
-	$(LATEXMK) $(LATEXMKOPT) -pdflatex="$(LATEX) $(LATEXOPT) $(NONSTOP) %O %S" $(MAIN)
+	$(LATEXMK) $(MAIN)
 
 .refresh:
 	touch .refresh
 
 pvc: aux $(MAIN).tex .refresh $(SOURCES) $(FIGURES)
-	$(LATEXMK) $(LATEXMKOPT) $(CONTINUOUS) -pdflatex="$(LATEX) $(LATEXOPT) $(NONSTOP) %O %S" $(MAIN)
+	$(LATEXMK) $(CONTINUOUS) $(MAIN)
 
 # Create a symlink for the final PDF
 symlink: aux

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Why this `latexmk` tool? Building/compiling the thesis requires multiple invocat
 
 If you're on a Unix-like system, there is also a `Makefile` which offers a little more functionality, like archiving and symlinking; see [this description](https://github.com/eyalroz/technion-iit-thesis/pull/19). If you don't know what a Makefile is - never mind.
 
+Some editor related tools like [`Vimtex`](https://github.com/lervag/vimtex), read the `.latexmkrc` settings and function in according to them.
+
 ### "Ok, I've compiled the template; what next?"
 
 You modify it until it becomes your own actual thesis:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A LaTeX document class for authoring masters' or doctoral thesis at the Technion
 1. Deploy a recent LaTeX distribution like (TeXLive or MikTeX, 2018 or later).
 2. Invoke the `latexmk` Make-like tool included in your TeX distribution, at the thesis' root folder (where `thesis.tex` is located), like so:
 
-       latexmk -xelatex thesis
+       latexmk thesis
 
 The template, as distributed, should compile without error (but with some warnings); once you've compiled it you have a `thesis.pdf` file, which you should read for additional information.
 


### PR DESCRIPTION
I encountered the need for the 1st commit because I use simply `make` to compile my thesis, and I noticed that it defaults to the `once` target, which doesn't include that nonstopmode `latexmk` flag, so I think most users would prefer this behavior.

The 2nd commit puts the `latexmk` details where it is more natural to put them - in `.latexmkrc`. This makes it easier for users who don't have `make` available get the same output. The 3rd commit mentions in the README that other tools that read `.latexmkrc` may benefit from the settings there.