### PR TITLE
Makefile: Don't assume there are graphics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ MAIN=thesis
 OUTPUT_FILENAME=thesis
 SOURCES := Makefile $(shell find . -regex '.*\.\(tex\|cls\|sty\|bib\)')
 ADDITIONAL_FILES := README.md
-FIGURES := $(shell find graphics/* -type f)
+FIGURES := $(shell find graphics/ -type f)
 
 all: symlink once
 


### PR DESCRIPTION
Don't use * expansion that fails when there are no files there.
