### PR TITLE
Cover pages/dates: Fix potential line jumping _before_ month

### DIFF
--- a/misc/iitthesis.cls
+++ b/misc/iitthesis.cls
@@ -552,7 +552,9 @@
     \normalsize
     \begin{center}
       Submitted to the Senate \\
-      of the Technion {\textemdash} Israel Institute of Technology
+      % Because this Hebrew month might be short (e.g 'Av'), LaTeX might
+      % typeset it on the preceding line, so we use another \\ just in case.
+      of the Technion {\textemdash} Israel Institute of Technology \\
       \iitthesis@JewishDateEnglish \hspace{1cm} Haifa \hspace{1cm} \iitthesis@GregorianDateEnglish
     \end{center}
   }}
@@ -592,7 +594,8 @@
     \normalsize
     \begin{center}
       Submitted to the Senate \\
-      of the Technion {\textemdash} Israel Institute of Technology
+      % Same reasoning for \\ as in the above
+      of the Technion {\textemdash} Israel Institute of Technology \\
       \iitthesis@JewishDateEnglish \hspace{1cm} Haifa \hspace{1cm} \iitthesis@GregorianDateEnglish
     \end{center}
   }
@@ -758,7 +761,7 @@
   \vphantom{\parbox{3in}{
      \normalsize
      \begin{center}
-       מוגש לסנט הטכניון {\textemdash} מכון טכנולוגי לישראל
+       מוגש לסנט הטכניון {\textemdash} מכון טכנולוגי לישראל \\
        \iitthesis@JewishDateHebrew
        \hspace{0.75cm} חיפה \hspace{0.75cm}
        \iitthesis@GregorianDateHebrew


### PR DESCRIPTION
While submitting my thesis in the Av Hebrew month, the school told me the Hebrew month in the English language, must appear in the same line as the rest of the date. In practice I had to change only 1 place where this affected me, but I changed it in all places I found, for consistency.
